### PR TITLE
Use decimals

### DIFF
--- a/lib/miner.ex
+++ b/lib/miner.ex
@@ -6,6 +6,7 @@ defmodule Miner do
   alias UltraDark.Transaction
   alias UltraDark.UtxoStore
   alias UltraDark.Utilities
+  alias Decimal, as: D
 
   def initialize(address) do
     Ledger.initialize
@@ -57,8 +58,9 @@ defmodule Miner do
     end
   end
 
+  @spec calculate_coinbase_amount(Block) :: Decimal
   defp calculate_coinbase_amount(block) do
-    Block.calculate_block_reward(block.index) + Block.total_block_fees(block.transactions)
+    D.add(Block.calculate_block_reward(block.index), Block.total_block_fees(block.transactions))
   end
 
   defp merge_block(coinbase, block) do

--- a/mix.exs
+++ b/mix.exs
@@ -25,6 +25,9 @@ defmodule Miner.Mixfile do
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do
-    [{:ultradark_core, "~> 0.1"}]
+    [
+      {:ultradark_core, "~> 0.1"},
+      {:decimal, "~> 1.0"}
+    ]
   end
 end


### PR DESCRIPTION
Due to changes in ultradark core, some uses of the Elixir float type need to be changed to Decimals.