### PR TITLE
Switch from Decimal to ions

### DIFF
--- a/lib/block_calculator/block_calculator.ex
+++ b/lib/block_calculator/block_calculator.ex
@@ -9,7 +9,6 @@ defmodule Miner.BlockCalculator do
   alias Elixium.Store.Ledger
   alias Elixium.Store.Oracle
   alias Elixium.Error
-  alias Decimal, as: D
 
   def start_link(address) do
     GenServer.start_link(__MODULE__, address, name: __MODULE__)
@@ -164,7 +163,7 @@ defmodule Miner.BlockCalculator do
 
     txs =
       transaction_pool
-      |> Enum.sort(& D.cmp(Transaction.calculate_fee(&1), Transaction.calculate_fee(&2)) == :gt || D.cmp(Transaction.calculate_fee(&1), Transaction.calculate_fee(&2)) == :eq)
+      |> Enum.sort(& Transaction.calculate_fee(&1) >= Transaction.calculate_fee(&2))
       |> fit_transactions([], remaining_space)
 
     GenServer.cast(__MODULE__, {:update_currently_mining_txs, txs})

--- a/lib/block_calculator/mine.ex
+++ b/lib/block_calculator/mine.ex
@@ -4,7 +4,6 @@ defmodule Miner.BlockCalculator.Mine do
   alias Elixium.Block
   alias Elixium.Store.Ledger
   alias Elixium.Transaction
-  alias Decimal, as: D
   alias Elixium.Utilities
   require Logger
 
@@ -90,10 +89,10 @@ defmodule Miner.BlockCalculator.Mine do
     end
   end
 
-  @spec calculate_coinbase_amount(Block) :: Decimal
+  @spec calculate_coinbase_amount(Block) :: integer
   defp calculate_coinbase_amount(block) do
     index = :binary.decode_unsigned(block.index)
-    D.add(Block.calculate_block_reward(index), Block.total_block_fees(block.transactions))
+    Block.calculate_block_reward(index) + Block.total_block_fees(block.transactions)
   end
 
   defp merge_block(coinbase, block) do
@@ -111,7 +110,7 @@ defmodule Miner.BlockCalculator.Mine do
       block.transactions
       |> Enum.at(0)
       |> Map.get(:outputs)
-      |> Enum.reduce(Decimal.new(0), fn o, acc -> Decimal.add(acc, o.amount) end)
+      |> Enum.reduce(0, & &1.amount + &2) 
 
     nonce = :binary.decode_unsigned(block.nonce)
     index = :binary.decode_unsigned(block.index)

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,6 @@ defmodule Miner.Mixfile do
   defp deps do
     [
       {:elixium_core, "~> 0.6"},
-      {:decimal, "~> 1.0"},
       {:poison, "~> 3.1"},
       {:distillery, "~> 2.0"},
       {:toml, "~> 0.5"},


### PR DESCRIPTION
Core now uses ions to represent UTXO values. This updates the miner to use the same units, and removes Decimal as a dependency. 

Requires [#92](https://github.com/ElixiumNetwork/elixium_core/pull/92) to be merged before this can be merged.